### PR TITLE
Add new profession that can be selected upon starting a new game

### DIFF
--- a/data/json/professions.json
+++ b/data/json/professions.json
@@ -622,6 +622,25 @@
   },
   {
     "type": "profession",
+    "id": "baseball_player",
+    "name": "Baseball Player",
+    "description": "You were playing at the local team.  With no one left to play baseball, you can eventually use your best friend for another purpose.  Home run!",
+    "points": 1,
+    "skills": [
+      { "level": 3, "name": "throw" },
+      { "level": 1, "name": "melee" }
+    ],
+    "items": {
+      "both": {
+        "items": [ "baseball", "tshirt", "jacket_light", "jeans", "socks", "sneakers", "helmet_ball", "sports_drink" ],
+        "entries": [ { "group": "charged_cell_phone" }, { "item": "bat", "custom-flags": [ "auto_wield" ] } ]
+      },
+      "male": [ "boxer_shorts" ],
+      "female": [ "sports_bra", "panties" ]
+    }
+  }, 
+  {
+    "type": "profession",
     "id": "basketball_player",
     "name": "Basketball Player",
     "description": "Your first major game was abruptly cancelled when zombies stormed the court.  Quick feet and good reflexes meant you were among the lucky few to escape the stadium alive.",


### PR DESCRIPTION

#### Summary

"SUMMARY: Content "New proffesion called "Baseball Player""

#### Purpose of change

Currently, there isn't any profession that starts with the baseball gear.


#### Testing

I started a new game and chose "Baseball Player" as a profession. Checked inventory and skills.
1.Start a new game. 
2.Select a scenario where you can choose all the professions.
3.Choose the "Baseball Player" profession and create the character.

#### Additional context

The profession in the profession selecting menu
![image](https://user-images.githubusercontent.com/75498935/101650408-906a3a00-3a44-11eb-99c5-32baa623781d.png)

Skills check
![image](https://user-images.githubusercontent.com/75498935/101651206-7a10ae00-3a45-11eb-8c8e-aa96bd53b390.png)

Inventory check
![image](https://user-images.githubusercontent.com/75498935/101651273-8bf25100-3a45-11eb-8671-4656947fddd2.png)


